### PR TITLE
MySqlConnectionFactory - Include Port

### DIFF
--- a/TicketMate.Persistence.Tests/DataRequestTests/BaseDataRequestTest.cs
+++ b/TicketMate.Persistence.Tests/DataRequestTests/BaseDataRequestTest.cs
@@ -16,14 +16,16 @@ namespace TicketMate.Persistence.Tests.DataRequestTests
                 Example:    
                             internal class Hidden
                             {
-                                internal const string DbServer = "";
-                                internal const string DbName = "";
-                                internal const string DbUserId = "";
-                                internal const string DbPassword = "";
+                                internal const string DbServer = "localhost";
+                                internal const string DbName = "TicketMate";
+                                internal const string DbUserId = "REPLACE THIS WITH DB USERNAME";
+                                internal const string DbPassword = "REPLACE THIS WITH DB PASSWORD";
+                                // Our Docker DB is exposed on port 3309
+                                internal const string DbPort = "3309"; 
                             }
             */
 
-            _dataAccess = new DataAccess(new MySqlConnectionFactory(Hidden.DbServer, Hidden.DbName, Hidden.DbUserId, Hidden.DbPassword));
+            _dataAccess = new DataAccess(new MySqlConnectionFactory(Hidden.DbServer, Hidden.DbPort, Hidden.DbName, Hidden.DbUserId, Hidden.DbPassword));
         }
     }
 }

--- a/TicketMate.Persistence.Tests/MySqlConnectionFactoryTests.cs
+++ b/TicketMate.Persistence.Tests/MySqlConnectionFactoryTests.cs
@@ -8,7 +8,7 @@ namespace TicketMate.Persistence.Tests
         [Fact]
         public void MySqlConnectionFactory_Given_ConnectionDetails_Should_ReturnConnection_ThatCanOpen()
         {
-            var connectionFactory = new MySqlConnectionFactory(Hidden.DbServer, Hidden.DbName, Hidden.DbUserId, Hidden.DbPassword);
+            var connectionFactory = new MySqlConnectionFactory(Hidden.DbServer, Hidden.DbPort, Hidden.DbName, Hidden.DbUserId, Hidden.DbPassword);
 
             using var connection = connectionFactory.NewConnection();
 
@@ -20,7 +20,7 @@ namespace TicketMate.Persistence.Tests
         [Fact]
         public void MySqlConnectionFactory_Given_ConnectionString_Should_ReturnConnection_ThatCanOpen()
         {
-            var connectionString = $"server={Hidden.DbServer};uid={Hidden.DbUserId};pwd={Hidden.DbPassword};database={Hidden.DbName}";
+            var connectionString = $"server={Hidden.DbServer};Port={Hidden.DbPort};uid={Hidden.DbUserId};pwd={Hidden.DbPassword};database={Hidden.DbName}";
 
             var connectionFactory = new MySqlConnectionFactory(connectionString);
 

--- a/TicketMate.Persistence/Implementation/MySqlConnectionFactory.cs
+++ b/TicketMate.Persistence/Implementation/MySqlConnectionFactory.cs
@@ -9,14 +9,15 @@ namespace TicketMate.Persistence.Implementation
 
         public MySqlConnectionFactory(string connectionString) => _connectionString = connectionString;
 
-        public MySqlConnectionFactory(string server, string databaseName, string userId, string password) 
-        { 
+        public MySqlConnectionFactory(string server, uint port, string databaseName, string userId, string password) 
+        {
             var builder = new MySqlConnectionStringBuilder()
             {
                 Server = server, // http://localhost:3309 from docker
                 Database = databaseName, // Ticketmate
                 UserID = userId, //ticketmate_dev_user
                 Password = password, // ticketmate_dev_pw
+                Port = port
             };
 
             _connectionString = builder.ConnectionString;


### PR DESCRIPTION
refactor MySqlConnectionFactory to include Port so that we can define it for using Database from Docker Container